### PR TITLE
Use IO::NULL, remove ptools dependency

### DIFF
--- a/lib/mkmf/lite.rb
+++ b/lib/mkmf/lite.rb
@@ -1,13 +1,12 @@
 require 'erb'
 require 'rbconfig'
 require 'tmpdir'
-require 'ptools'
 require 'open3'
 
 module Mkmf
   module Lite
     # The version of the mkmf-lite library
-    MKMF_LITE_VERSION = '0.4.0'.freeze
+    MKMF_LITE_VERSION = '0.4.1'.freeze
 
     private
 
@@ -171,8 +170,8 @@ module Mkmf
           command += cpp_source_file
 
           # Temporarily close these
-          $stderr.reopen(File.null)
-          $stdout.reopen(File.null)
+          $stderr.reopen(IO::NULL)
+          $stdout.reopen(IO::NULL)
 
           if system(command)
             $stdout.reopen(stdout_orig) # We need this back for open3 to work.
@@ -223,8 +222,8 @@ module Mkmf
           command += cpp_out_file + ' '
           command += cpp_source_file
 
-          $stderr.reopen(File.null)
-          $stdout.reopen(File.null)
+          $stderr.reopen(IO::NULL)
+          $stdout.reopen(IO::NULL)
           boolean = system(command)
         }
       ensure

--- a/mkmf-lite.gemspec
+++ b/mkmf-lite.gemspec
@@ -3,7 +3,7 @@ require 'rubygems'
 Gem::Specification.new do |spec|
   spec.name       = 'mkmf-lite'
   spec.summary    = 'A lighter version of mkmf designed for use as a library'
-  spec.version    = '0.4.0'
+  spec.version    = '0.4.1'
   spec.author     = 'Daniel J. Berger'
   spec.license    = 'Apache-2.0'
   spec.email      = 'djberg96@gmail.com'
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
 
   spec.extra_rdoc_files = Dir['*.rdoc']
    
-  spec.add_dependency('ptools', '~> 1.3')
   spec.add_development_dependency('rspec', '~> 3.9')
 
   spec.metadata = {

--- a/spec/mkmf_lite_spec.rb
+++ b/spec/mkmf_lite_spec.rb
@@ -16,7 +16,7 @@ describe Mkmf::Lite do
 
   describe "constants" do
     example "version information" do
-      expect(described_class::MKMF_LITE_VERSION).to eq('0.4.0')
+      expect(described_class::MKMF_LITE_VERSION).to eq('0.4.1')
       expect(described_class::MKMF_LITE_VERSION).to be_frozen
     end
   end


### PR DESCRIPTION
Remove the ptools dependency since we can just use `IO::NULL` instead. Plus, the `File.null` method was recently removed from ptools.