### PR TITLE
Add memoist gem and memoize most things

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.6.0 - 26-Sep-2023
+* Added the memoist gem and memoized the results of all public methods since
+  the odds of them changing between calls is basically zero.
+
 ## 0.5.2 - 24-Mar-2023
 * Lots of rubocop updates and minor cleanup, including the addition of
   rubocop and rubocop-rspec as deve dependencies.

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ used in conjunction with FFI. Also, the source code is quite readable.
 It does not package C extensions, nor generate a log file or a Makefile. It
 does, however, require that you have a C compiler somewhere on your system.
 
+As of version 0.6.0 it memoizes the results of any checks that you make
+since they wouldn't ever change without requiring a reboot/restart of your
+server, container, etc, anyway.
+
 ## Known Issues
-You may see this warning from JRuby 1.4.x and earlier:
-
-warning: Useless use of a variable in void context.
-
-You can ignore these (or, upgrade your Jruby).
+Very old versions of JRuby will emit a warning. You should upgrade.
 
 ## License
 Apache-2.0

--- a/lib/mkmf/lite.rb
+++ b/lib/mkmf/lite.rb
@@ -6,14 +6,17 @@ require 'tmpdir'
 require 'open3'
 require 'ptools'
 require 'fileutils'
+require 'memoist'
 
 # The Mkmf module serves as a namespace only.
 module Mkmf
   # The Lite module scopes the Mkmf module to differentiate it from the
   # Mkmf module in the standard library.
   module Lite
+    extend Memoist
+
     # The version of the mkmf-lite library
-    MKMF_LITE_VERSION = '0.5.2'
+    MKMF_LITE_VERSION = '0.6.0'
 
     private
 
@@ -24,6 +27,8 @@ module Mkmf
       command
     end
     # rubocop:enable Layout/LineLength
+
+    memoize :cpp_command
 
     def cpp_source_file
       'conftest.c'
@@ -37,6 +42,8 @@ module Mkmf
       end
     end
 
+    memoize :cpp_out_file
+
     # TODO: We should adjust this based on OS. For now we're using
     # arguments I think you'll typically see set on Linux and BSD.
     def cpp_libraries
@@ -46,6 +53,8 @@ module Mkmf
         '-lrt -ldl -lcrypt -lm'
       end
     end
+
+    memoize :cpp_libraries
 
     public
 
@@ -69,6 +78,8 @@ module Mkmf
       try_to_compile(code, options)
     end
 
+    memoize :have_header
+
     # Check for the presence of the given +function+ in the common header
     # files, or within any +headers+ that you provide.
     #
@@ -88,6 +99,8 @@ module Mkmf
       try_to_compile(ptr_code) || try_to_compile(std_code)
     end
 
+    memoize :have_func
+
     # Checks whether or not the struct of type +struct_type+ contains the
     # +struct_member+. If it does not, or the struct type cannot be found,
     # then false is returned.
@@ -103,6 +116,8 @@ module Mkmf
       try_to_compile(code)
     end
 
+    memoize :have_struct_member
+
     # Returns the value of the given +constant+ (which could also be a macro)
     # using +headers+, or common headers if no headers are specified.
     #
@@ -116,6 +131,8 @@ module Mkmf
 
       try_to_execute(code)
     end
+
+    memoize :check_valueof
 
     # Returns the sizeof +type+ using +headers+, or common headers if no
     # headers are specified.
@@ -137,6 +154,8 @@ module Mkmf
 
       try_to_execute(code)
     end
+
+    memoize :check_sizeof
 
     private
 

--- a/mkmf-lite.gemspec
+++ b/mkmf-lite.gemspec
@@ -3,7 +3,7 @@ require 'rubygems'
 Gem::Specification.new do |spec|
   spec.name       = 'mkmf-lite'
   spec.summary    = 'A lighter version of mkmf designed for use as a library'
-  spec.version    = '0.5.2'
+  spec.version    = '0.6.0'
   spec.author     = 'Daniel J. Berger'
   spec.license    = 'Apache-2.0'
   spec.email      = 'djberg96@gmail.com'
@@ -13,6 +13,8 @@ Gem::Specification.new do |spec|
   spec.cert_chain = ['certs/djberg96_pub.pem']
 
   spec.add_dependency('ptools', '~> 1.4')
+  spec.add_dependency('memoist', '~> 0.16.2')
+
   spec.add_development_dependency('rake')
   spec.add_development_dependency('rspec', '~> 3.9')
   spec.add_development_dependency('rubocop')

--- a/spec/mkmf_lite_spec.rb
+++ b/spec/mkmf_lite_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Mkmf::Lite do
 
   describe 'constants' do
     example 'version information' do
-      expect(described_class::MKMF_LITE_VERSION).to eq('0.5.2')
+      expect(described_class::MKMF_LITE_VERSION).to eq('0.6.0')
       expect(described_class::MKMF_LITE_VERSION).to be_frozen
     end
   end
@@ -82,7 +82,7 @@ RSpec.describe Mkmf::Lite do
     end
 
     example 'have_struct_member accepts a maximum of three arguments' do
-      expect{ subject.have_struct_member('struct passwd', 'pw_name', 'pwd.h', true) }.to raise_error(ArgumentError)
+      expect{ subject.have_struct_member('struct passwd', 'pw_name', 'pwd.h', 1) }.to raise_error(ArgumentError)
     end
   end
 


### PR DESCRIPTION
Since the odds of any of the mkmf method checks changing between calls is somewhere approaching zero* it makes sense to memoize most of the methods.

I did have to alter one spec because the memoist gem assumes that a `true` argument added at the end of an arg list refreshes the memoization.

* It would have to be a rather significant and at least somewhat radical change in the underlying header files and/or compiler to cause a shift, and that would almost certainly require a reboot/restart anyway.