### PR TITLE
Add directory options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 0.7.2 - 13-Mar-2025
+* Allow option of adding directories to check_sizeof and check_valueof methods.
+
 ## 0.7.1 - 29-Sep-2024
 * Skip adding compiler switches for JRuby, which chokes on them for some reason.
 

--- a/mkmf-lite.gemspec
+++ b/mkmf-lite.gemspec
@@ -3,7 +3,7 @@ require 'rubygems'
 Gem::Specification.new do |spec|
   spec.name       = 'mkmf-lite'
   spec.summary    = 'A lighter version of mkmf designed for use as a library'
-  spec.version    = '0.7.1'
+  spec.version    = '0.7.2'
   spec.author     = 'Daniel J. Berger'
   spec.license    = 'Apache-2.0'
   spec.email      = 'djberg96@gmail.com'

--- a/spec/mkmf_lite_spec.rb
+++ b/spec/mkmf_lite_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Mkmf::Lite do
 
   describe 'constants' do
     example 'version information' do
-      expect(described_class::MKMF_LITE_VERSION).to eq('0.7.1')
+      expect(described_class::MKMF_LITE_VERSION).to eq('0.7.2')
       expect(described_class::MKMF_LITE_VERSION).to be_frozen
     end
   end
@@ -96,8 +96,8 @@ RSpec.describe Mkmf::Lite do
       expect{ subject.check_valueof }.to raise_error(ArgumentError)
     end
 
-    example 'check_valueof accepts a maximum of two arguments' do
-      expect{ subject.check_valueof(constant, 'stdio.h', 1) }.to raise_error(ArgumentError)
+    example 'check_valueof accepts directory arguments' do
+      expect{ subject.check_valueof(constant, 'stdio.h', ['/usr/include']) }.not_to raise_error
     end
 
     example 'check_valueof works with one or two arguments' do
@@ -122,8 +122,8 @@ RSpec.describe Mkmf::Lite do
       expect{ subject.check_sizeof }.to raise_error(ArgumentError)
     end
 
-    example 'check_sizeof accepts a maximum of two arguments' do
-      expect{ subject.check_sizeof('div_t', 'stdlib.h', 1) }.to raise_error(ArgumentError)
+    example 'check_sizeof accepts directory arguments' do
+      expect{ subject.check_sizeof('div_t', 'stdlib.h', ['/usr/include']) }.not_to raise_error
     end
 
     example 'check_sizeof works with one or two arguments' do


### PR DESCRIPTION
This PR allows optional directories to be passed to the `check_sizeof` and `check_valueof` methods. More generically, it allows optional directories in the underlying `try_to_execute` method.