### PR TITLE
Add check_offsetof method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 0.7.3 - 21-Mar-2025
+* Add check_offsetof method.
+
 ## 0.7.2 - 13-Mar-2025
 * Allow option of adding directories to check_sizeof and check_valueof methods.
 

--- a/lib/mkmf/lite.rb
+++ b/lib/mkmf/lite.rb
@@ -16,7 +16,7 @@ module Mkmf
     extend Memoist
 
     # The version of the mkmf-lite library
-    MKMF_LITE_VERSION = '0.7.2'
+    MKMF_LITE_VERSION = '0.7.3'
 
     private
 

--- a/lib/mkmf/lite.rb
+++ b/lib/mkmf/lite.rb
@@ -184,6 +184,38 @@ module Mkmf
 
     memoize :check_sizeof
 
+    # Returns the offset of +field+ within +struct_type+ using +headers+,
+    # or common headers, plus stddef.h, if no headers are specified.
+    #
+    # If this method fails an error is raised. This could happen if the field
+    # can't be found and/or the header files do not include the indicated type.
+    # It will also fail if the field is a bit field.
+    #
+    # Example:
+    #
+    #   class Foo
+    #     include Mkmf::Lite
+    #     utsname = check_offsetof('struct utsname', 'release', 'sys/utsname.h')
+    #   end
+    #
+    def check_offsetof(struct_type, field, headers = [], *directories)
+      headers = get_header_string(headers)
+      erb = ERB.new(read_template('check_offsetof.erb'))
+      code = erb.result(binding)
+
+      if directories.empty?
+        options = nil
+      else
+        options = ''
+        directories.each{ |dir| options += "-I#{dir} " }
+        options.rstrip!
+      end
+
+      try_to_execute(code, options)
+    end
+
+    memoize :check_offsetof
+
     private
 
     # Take an array of header file names (or convert it to an array if it's a

--- a/lib/mkmf/templates/check_offsetof.erb
+++ b/lib/mkmf/templates/check_offsetof.erb
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <stddef.h>
+
+<%= headers %>
+
+int conftest_const = (int)(offsetof(<%= struct_type %>, <%= field %>));
+
+int main(){
+  printf("%d\n", conftest_const);
+  return 0;
+}

--- a/mkmf-lite.gemspec
+++ b/mkmf-lite.gemspec
@@ -3,7 +3,7 @@ require 'rubygems'
 Gem::Specification.new do |spec|
   spec.name       = 'mkmf-lite'
   spec.summary    = 'A lighter version of mkmf designed for use as a library'
-  spec.version    = '0.7.2'
+  spec.version    = '0.7.3'
   spec.author     = 'Daniel J. Berger'
   spec.license    = 'Apache-2.0'
   spec.email      = 'djberg96@gmail.com'

--- a/spec/mkmf_lite_spec.rb
+++ b/spec/mkmf_lite_spec.rb
@@ -112,6 +112,33 @@ RSpec.describe Mkmf::Lite do
     end
   end
 
+  context 'check_offsetof' do
+    let(:st_field){ 'st_dev' }
+
+    example 'check_offsetof basic functionality' do
+      expect(subject).to respond_to(:check_offsetof)
+      expect{ subject.check_offsetof(st_type, st_field, st_header) }.not_to raise_error
+    end
+
+    example 'check_offsetof requires at least two arguments' do
+      expect{ subject.check_offsetof }.to raise_error(ArgumentError)
+      expect{ subject.check_offsetof(st_type) }.to raise_error(ArgumentError)
+    end
+
+    example 'check_offsetof accepts directory arguments' do
+      expect{ subject.check_offsetof(st_type, st_field, [st_header, 'stdlib.h'], ['/usr/include']) }.not_to raise_error
+    end
+
+    example 'check_offsetof returns an integer value' do
+      size1 = subject.check_offsetof(st_type, st_field, st_header)
+      size2 = subject.check_offsetof(st_type, 'st_ino', st_header)
+      expect(size1).to be_a(Integer)
+      expect(size2).to be_a(Integer)
+      expect(size1).to eq(0)
+      expect(size2).to be > size1
+    end
+  end
+
   context 'check_sizeof' do
     example 'check_sizeof basic functionality' do
       expect(subject).to respond_to(:check_sizeof)

--- a/spec/mkmf_lite_spec.rb
+++ b/spec/mkmf_lite_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Mkmf::Lite do
 
   describe 'constants' do
     example 'version information' do
-      expect(described_class::MKMF_LITE_VERSION).to eq('0.7.2')
+      expect(described_class::MKMF_LITE_VERSION).to eq('0.7.3')
       expect(described_class::MKMF_LITE_VERSION).to be_frozen
     end
   end


### PR DESCRIPTION
I've been recently trying to wrap a C library (GPGME) with ruby-ffi, but have run into issues with structs that have some bitfields, so I need to know where exactly the offset is of certain fields in order to recreate an FFI::Struct. It also helps with defining structs in general.