### PR TITLE
Cross platform updates

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -44,5 +44,5 @@ jobs:
           export CC=clang
           export CFLAGS="-Wno-error=unused-command-line-argument-hard-error-in-future"
           gem install bundler --no-document
-          bundle install --quiet
+          bundle install --quiet --jobs 1
           bundle exec rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,6 +41,8 @@ jobs:
           pkg install -y ruby devel/ruby-gems
 
         run: |
+          export CC=clang
+          export CFLAGS="-Wno-error=unused-command-line-argument-hard-error-in-future"
           gem install bundler --no-document
           bundle install --quiet
           bundle exec rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,3 +28,19 @@ jobs:
         bundler-cache: true
     - name: Run tests
       run: bundle exec rake
+
+  freebsd:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Test in FreeBSD
+      uses: vmactions/freebsd-vm@v1
+      with:
+        usesh: true
+        prepare: |
+          pkg install -y ruby devel/ruby-gems
+
+        run: |
+          gem install bundler --no-document
+          bundle install --quiet
+          bundle exec rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby-version: ['3.2', '3.3', '3.4']
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,14 @@
-require: rubocop-rspec
+plugins:
+  - rubocop-rspec
 
 RSpec/MultipleExpectations:
   Max: 4
 RSpec/ContextWording:
   Enabled: false
-RSpec/FilePath:
-  SpecSuffixOnly: true
+RSpec/ExampleLength:
+  Max: 6
+RSpec/SpecFilePathFormat:
+  Enabled: false
 RSpec/InstanceVariable:
   Enabled: false
 RSpec/NamedSubject:
@@ -60,7 +63,7 @@ Metrics/CyclomaticComplexity:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Enabled: false
 Naming/RescuedExceptionsVariableName:
   PreferredName: 'err'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## 0.8.0 - ???
+## 0.8.0 - 29-Jun-2026
 * Removed implicit Linux-style library flags from compiler probes.
 * Compile probes now use argv-style command execution and per-probe temporary
   directories.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 * Compile probes now use argv-style command execution and per-probe temporary
   directories.
 * Improved support for include directories with spaces.
+* Added FreeBSD CI coverage.
 * Updated RuboCop configuration for current rubocop-rspec.
 
 ## 0.7.5 - 24-Dec-2025

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## 0.8.0 - ???
+* Removed implicit Linux-style library flags from compiler probes.
+* Compile probes now use argv-style command execution and per-probe temporary
+  directories.
+* Improved support for include directories with spaces.
+* Updated RuboCop configuration for current rubocop-rspec.
+
 ## 0.7.5 - 24-Dec-2025
 * Automatically include homebrew lib for have_library on Macs.
 * Modified the have_library to work with or without leading "lib".

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,104 @@
+# Roadmap
+
+This branch focuses on making `mkmf-lite` more platform-neutral, safer to use
+inside applications, and easier to validate across Unix-like systems. The main
+goal is to avoid FreeBSD-specific special cases where a more general portability
+improvement would solve the same problem.
+
+## 0.8.0 - Portability Foundation
+
+Keep the public API stable and harden the existing implementation.
+
+* Replace hard-coded default libraries in `cpp_libraries`.
+* Stop assuming Linux-style `rt`, `dl`, `crypt`, and `m` availability.
+* Fix the clang branch that currently emits `-Lrt`, `-Ldl`, `-Lcrypt`, and
+  `-Lm`; these are library search path flags, not library link flags.
+* Prefer Ruby's `RbConfig` values where they are appropriate, and only add
+  explicit libraries when a probe requires them.
+* Use a per-probe temporary directory instead of shared `conftest.c` and
+  `conftest.exe` files in `Dir.tmpdir`.
+* Avoid global `Dir.chdir` during probe compilation when practical.
+* Replace shell-built compiler command strings with argv-style execution.
+* Capture compiler diagnostics internally without emitting unwanted output.
+* Add FreeBSD CI coverage, likely through Cirrus CI or a GitHub Actions
+  FreeBSD runner.
+
+## 0.9.0 - API Improvements
+
+Add clearer extension points while preserving the existing positional API.
+
+* Add keyword options for include directories, library directories, compile
+  flags, and link flags.
+* Consider examples such as:
+
+  ```ruby
+  have_header('foo.h', include_dirs: ['/usr/local/include'])
+  have_library(
+    'foo',
+    'foo_init',
+    headers: ['foo.h'],
+    lib_dirs: ['/usr/local/lib']
+  )
+  ```
+
+* Add access to the last failed compile command and diagnostics.
+* Consider a small configuration API for global defaults such as compiler,
+  include paths, library paths, and extra flags.
+* Keep memoized public probes, but document when memoization applies and how
+  callers should think about process lifetime.
+
+## 1.0.0 - Stable Contract
+
+Finalize the behavior expected by downstream users.
+
+* Document the supported public API and compatibility expectations.
+* Remove unnecessary runtime dependencies where feasible.
+* Document compiler selection, probe memoization, error handling, and platform
+  support.
+* Keep the library focused on lightweight compile/link probes rather than
+  becoming a replacement for stdlib `mkmf`.
+
+## C Probe Correctness
+
+These improvements can land in the earliest release where they fit cleanly.
+
+* Print `sizeof` results using `size_t` and `%zu`.
+* Print `offsetof` results with an appropriate unsigned size format.
+* Avoid casting sizes and offsets down to `int`.
+* Review function probes under stricter C modes, where implicit declarations
+  and old-style function assumptions may fail.
+* Consider compile-time assertions for probes that only need success or failure.
+
+## Dependency Reduction
+
+Reducing dependencies is useful, but should not distract from the portability
+foundation.
+
+* Remove `ptools` if it is only needed for `File.which`.
+* Replace `File.which` with a small internal executable lookup based on
+  `ENV['PATH']`.
+* Reevaluate `memoist` after the probe and command execution behavior is stable.
+
+## Test Coverage
+
+The test suite should exercise command construction and failure modes, not only
+successful local probes.
+
+* Add specs for generated compiler/linker arguments.
+* Test include and library directories containing spaces.
+* Test library names with and without a leading `lib` prefix.
+* Test parallel probe invocations to catch temporary file collisions.
+* Add mocked `RbConfig` coverage for Linux, macOS, FreeBSD, Windows/MSVC, and
+  JRuby.
+* Add a regression test proving clang does not receive bogus `-Lrt`-style
+  flags.
+
+## Documentation
+
+Documentation should make the portability model explicit.
+
+* Explain that probes compile tiny C programs using Ruby's configured compiler.
+* Clarify how `mkmf-lite` differs from stdlib `mkmf`.
+* Add FFI-oriented examples for common Unix-like use cases.
+* Document how to pass include and library paths for ports-installed libraries,
+  especially `/usr/local/include` and `/usr/local/lib` on FreeBSD.

--- a/lib/mkmf/lite.rb
+++ b/lib/mkmf/lite.rb
@@ -16,7 +16,7 @@ module Mkmf
     extend Memoist
 
     # The version of the mkmf-lite library
-    MKMF_LITE_VERSION = '0.7.5'
+    MKMF_LITE_VERSION = '0.8.0'
 
     private
 

--- a/lib/mkmf/lite.rb
+++ b/lib/mkmf/lite.rb
@@ -4,8 +4,8 @@ require 'erb'
 require 'rbconfig'
 require 'tmpdir'
 require 'open3'
+require 'shellwords'
 require 'ptools'
-require 'fileutils'
 require 'memoist'
 
 # The Mkmf module serves as a namespace only.
@@ -51,24 +51,16 @@ module Mkmf
       'conftest.c'
     end
 
-    def cpp_out_file
+    def cpp_out_file(output_file = 'conftest.exe')
       if windows_with_cl_compiler?
-        '/Feconftest.exe'
+        "/Fe#{output_file}"
       else
-        '-o conftest.exe'
+        ['-o', output_file]
       end
     end
 
-    memoize :cpp_out_file
-
     def cpp_libraries
-      return nil if windows_with_cl_compiler? || jruby?
-
-      if cpp_command.match?(/clang/i)
-        '-Lrt -Ldl -Lcrypt -Lm'
-      else
-        '-lrt -ldl -lcrypt -lm'
-      end
+      nil
     end
 
     memoize :cpp_libraries
@@ -84,7 +76,7 @@ module Mkmf
         paths << '-L/usr/local/lib' if File.directory?('/usr/local/lib')
       end
 
-      paths.empty? ? nil : paths.join(' ')
+      paths.empty? ? nil : paths
     end
 
     memoize :cpp_library_paths
@@ -241,35 +233,31 @@ module Mkmf
     def build_directory_options(directories)
       return nil if directories.empty?
 
-      directories.map { |dir| "-I#{dir}" }.join(' ')
+      directories.flatten.map { |dir| "-I#{dir}" }
     end
 
-    def build_compile_command(command_options = nil, library_options = nil)
-      command_parts = [cpp_command]
-      command_parts << command_options if command_options
-      command_parts << cpp_library_paths if cpp_library_paths
-      command_parts << cpp_libraries if cpp_libraries
-      command_parts << cpp_defs
-      command_parts << cpp_out_file
-      command_parts << cpp_source_file
-      command_parts << library_options if library_options
+    def build_compile_command(command_options = nil, library_options = nil, paths = {})
+      source_file = paths.fetch(:source_file, cpp_source_file)
+      output_file = paths.fetch(:output_file, 'conftest.exe')
 
-      command_parts.compact.join(' ')
+      command_parts = shellwords(cpp_command)
+      command_parts.concat(shellwords(command_options))
+      command_parts.concat(shellwords(cpp_library_paths))
+      command_parts.concat(shellwords(cpp_libraries))
+      command_parts.concat(shellwords(cpp_defs))
+      command_parts.concat(shellwords(cpp_out_file(output_file)))
+      command_parts << source_file
+      command_parts.concat(shellwords(library_options))
+
+      command_parts
     end
 
-    def with_suppressed_output
-      stderr_orig = $stderr.dup
-      stdout_orig = $stdout.dup
-
-      $stderr.reopen(IO::NULL)
-      $stdout.reopen(IO::NULL)
-
-      yield
-    ensure
-      $stderr.reopen(stderr_orig)
-      $stdout.reopen(stdout_orig)
-      stderr_orig.close
-      stdout_orig.close
+    def shellwords(options)
+      if options.is_a?(Array)
+        options.flatten.compact.map(&:to_s)
+      else
+        Shellwords.split(options.to_s)
+      end
     end
 
     # Take an array of header file names (or convert it to an array if it's a
@@ -303,56 +291,53 @@ module Mkmf
     # The code generated is expected to print a number to STDOUT, which
     # is then grabbed and returned as an integer.
     #
-    # Note that $stderr is temporarily redirected to the null device because
-    # we don't actually care about the reason for failure, though a Ruby
-    # error is raised if the compilation step fails.
-    #
     def try_to_execute(code, command_options = nil)
       result = 0
 
-      Dir.chdir(Dir.tmpdir) do
-        File.write(cpp_source_file, code)
-        command = build_compile_command(command_options)
+      Dir.mktmpdir('mkmf-lite') do |dir|
+        source_file = File.join(dir, cpp_source_file)
+        output_file = File.join(dir, 'conftest.exe')
+        File.write(source_file, code)
+        command = build_compile_command(
+          command_options,
+          nil,
+          :source_file => source_file,
+          :output_file => output_file
+        )
 
-        compilation_successful = with_suppressed_output { system(command) }
+        _stdout, stderr, status = Open3.capture3(*command)
 
-        if compilation_successful
-          conftest = File::ALT_SEPARATOR ? 'conftest.exe' : './conftest.exe'
-
-          Open3.popen3(conftest) do |stdin, stdout, stderr|
-            stdin.close
-            stderr.close
-            output = stdout.gets
-            result = output&.chomp&.to_i || 0
-          end
+        if status.success?
+          output, = Open3.capture2(output_file)
+          result = output.chomp.to_i
         else
-          raise StandardError, "Failed to compile source code with command '#{command}':\n===\n#{code}==="
+          message = "Failed to compile source code with command '#{command.shelljoin}':\n#{stderr}===\n#{code}==="
+          raise StandardError, message
         end
       end
 
       result
-    ensure
-      FileUtils.rm_f(File.join(Dir.tmpdir, cpp_source_file))
-      FileUtils.rm_f(File.join(Dir.tmpdir, 'conftest.exe'))
     end
 
     # Create a temporary bit of C source code in the temp directory, and
     # try to compile it. If it succeeds, return true. Otherwise, return
     # false.
     #
-    # Note that $stderr is temporarily redirected to the null device because
-    # we don't actually care about the reason for failure.
-    #
     def try_to_compile(code, command_options = nil, library_options = nil)
-      Dir.chdir(Dir.tmpdir) do
-        File.write(cpp_source_file, code)
-        command = build_compile_command(command_options, library_options)
+      Dir.mktmpdir('mkmf-lite') do |dir|
+        source_file = File.join(dir, cpp_source_file)
+        output_file = File.join(dir, 'conftest.exe')
+        File.write(source_file, code)
+        command = build_compile_command(
+          command_options,
+          library_options,
+          :source_file => source_file,
+          :output_file => output_file
+        )
 
-        with_suppressed_output { system(command) }
+        _stdout, _stderr, status = Open3.capture3(*command)
+        status.success?
       end
-    ensure
-      FileUtils.rm_f(File.join(Dir.tmpdir, cpp_source_file))
-      FileUtils.rm_f(File.join(Dir.tmpdir, 'conftest.exe'))
     end
 
     # Slurp the contents of the template file for evaluation later.

--- a/mkmf-lite.gemspec
+++ b/mkmf-lite.gemspec
@@ -3,7 +3,7 @@ require 'rubygems'
 Gem::Specification.new do |spec|
   spec.name       = 'mkmf-lite'
   spec.summary    = 'A lighter version of mkmf designed for use as a library'
-  spec.version    = '0.7.5'
+  spec.version    = '0.8.0'
   spec.author     = 'Daniel J. Berger'
   spec.license    = 'Apache-2.0'
   spec.email      = 'djberg96@gmail.com'

--- a/spec/mkmf_lite_spec.rb
+++ b/spec/mkmf_lite_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Mkmf::Lite do
 
   describe 'constants' do
     example 'version information' do
-      expect(described_class::MKMF_LITE_VERSION).to eq('0.7.5')
+      expect(described_class::MKMF_LITE_VERSION).to eq('0.8.0')
       expect(described_class::MKMF_LITE_VERSION).to be_frozen
     end
   end

--- a/spec/mkmf_lite_spec.rb
+++ b/spec/mkmf_lite_spec.rb
@@ -9,6 +9,7 @@ require 'rubygems'
 require 'rspec'
 require 'mkmf/lite'
 require 'fileutils'
+require 'tmpdir'
 
 RSpec.describe Mkmf::Lite do
   subject { Class.new{ |obj| obj.extend Mkmf::Lite } }
@@ -38,6 +39,16 @@ RSpec.describe Mkmf::Lite do
     example 'have_header accepts an array of directories as a second argument' do
       expect{ subject.have_header('stdio.h', '/usr/local/include') }.not_to raise_error
       expect{ subject.have_header('stdio.h', '/usr/local/include', '/usr/include') }.not_to raise_error
+    end
+
+    example 'have_header accepts a directory with spaces' do
+      Dir.mktmpdir('mkmf lite') do |dir|
+        header = 'mkmf_lite_space_header.h'
+
+        File.write(File.join(dir, header), "#define MKMF_LITE_SPACE_HEADER 1\n")
+
+        expect(subject.have_header(header, dir)).to be(true)
+      end
     end
   end
 
@@ -192,6 +203,31 @@ RSpec.describe Mkmf::Lite do
 
     example 'have_library accepts a maximum of three arguments' do
       expect{ subject.have_library('m', 'sqrt', 'math.h', 'bogus') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe 'command construction' do
+    let(:command_with_spaces) do
+      subject.send(
+        :build_compile_command,
+        ['-I/tmp/include dir'],
+        nil,
+        :source_file => 'source.c',
+        :output_file => 'output file'
+      )
+    end
+
+    example 'build_compile_command returns argv-style command parts' do
+      expect(command_with_spaces).to include('-I/tmp/include dir')
+      expect(command_with_spaces).to include('source.c')
+      expect(command_with_spaces.any? { |part| part.include?('output file') }).to be(true)
+    end
+
+    example 'build_compile_command does not include implicit Linux libraries' do
+      command = subject.send(:build_compile_command)
+
+      expect(command).not_to include('-Lrt', '-Ldl', '-Lcrypt', '-Lm')
+      expect(command).not_to include('-lrt', '-ldl', '-lcrypt', '-lm')
     end
   end
 end


### PR DESCRIPTION
* Removed implicit Linux-style library flags from compiler probes.
* Compile probes now use argv-style command execution and per-probe temporary
  directories.
* Improved support for include directories with spaces.
* Added FreeBSD CI coverage.
* Updated RuboCop configuration for current rubocop-rspec.