### PR TITLE
Add global config option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 0.8.2 - TBD
+* Added `Mkmf::Lite.configure` for process-wide compiler, include directory,
+  library directory, compile flag, and link flag defaults.
+* Configuration changes now clear memoized probe results on existing
+  `Mkmf::Lite` extenders.
+
 ## 0.8.1 - 30-Jun-2026
 * Improved generated C formatting for size, offset, and constant probes.
 * Simplified struct member probes to use a compile-only member check.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## 0.8.2 - TBD
+## 0.9.0 - 5-Jul-2026
 * Added `Mkmf::Lite.configure` for process-wide compiler, include directory,
   library directory, compile flag, and link flag defaults.
 * Configuration changes now clear memoized probe results on existing

--- a/README.md
+++ b/README.md
@@ -109,6 +109,23 @@ class LocalHeader
 end
 ```
 
+## Configuration
+Use `Mkmf::Lite.configure` to set process-wide defaults that should apply to
+all probes:
+
+```ruby
+Mkmf::Lite.configure do |config|
+  config.compiler = 'clang'
+  config.include_dirs = ['/opt/local/include']
+  config.lib_dirs = ['/opt/local/lib']
+  config.cflags = ['-D_GNU_SOURCE']
+  config.ldflags = ['-Wl,-rpath,/opt/local/lib']
+end
+```
+
+The same configuration object is available from any object that extends
+`Mkmf::Lite`, so local setup code can call `configure` there as well.
+
 ## Memoization
 As of version 0.6.0, public probe results are memoized for the lifetime of the
 object that extends `Mkmf::Lite`. The method arguments are part of the cache
@@ -116,9 +133,9 @@ key, so `have_header('foo.h')` and `have_header('foo.h', '/usr/local/include')`
 are distinct checks.
 
 This fits the normal use case where compiler configuration, headers, and system
-libraries do not change while the Ruby process is running. If you need to probe
-again after changing the environment, create a new object or restart the
-process.
+libraries do not change while the Ruby process is running. Calling
+`Mkmf::Lite.configure` clears memoized probe results on objects that already
+extended `Mkmf::Lite`, so repeated checks use the updated defaults.
 
 ## Known Issues
 JRuby may emit warnings on some platforms.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -123,10 +123,12 @@ have_library(
 
 Consider a small configuration API if repeated keyword arguments become noisy.
 
-* Evaluate `Mkmf::Lite.configure` for global defaults.
-* Support compiler, include directories, library directories, compile flags,
+Status: Done.
+
+* [x] Evaluate `Mkmf::Lite.configure` for global defaults.
+* [x] Support compiler, include directories, library directories, compile flags,
   and link flags as possible defaults.
-* Make configuration interaction with memoized probe results explicit.
+* [x] Make configuration interaction with memoized probe results explicit.
 
 ### 1.0.0 - Stable Contract
 

--- a/lib/mkmf/lite.rb
+++ b/lib/mkmf/lite.rb
@@ -52,7 +52,7 @@ module Mkmf
     end
 
     # The version of the mkmf-lite library
-    MKMF_LITE_VERSION = '0.8.1'
+    MKMF_LITE_VERSION = '0.9.0'
 
     class << self
       def configuration

--- a/lib/mkmf/lite.rb
+++ b/lib/mkmf/lite.rb
@@ -15,8 +15,74 @@ module Mkmf
   module Lite
     extend Memoist
 
+    # Stores process-wide defaults for compiler probe commands.
+    class Configuration
+      attr_accessor :compiler
+      attr_reader :include_dirs, :lib_dirs, :cflags, :ldflags
+
+      def initialize
+        @compiler = nil
+        @include_dirs = []
+        @lib_dirs = []
+        @cflags = []
+        @ldflags = []
+      end
+
+      def include_dirs=(dirs)
+        @include_dirs = normalize_options(dirs)
+      end
+
+      def lib_dirs=(dirs)
+        @lib_dirs = normalize_options(dirs)
+      end
+
+      def cflags=(flags)
+        @cflags = normalize_options(flags)
+      end
+
+      def ldflags=(flags)
+        @ldflags = normalize_options(flags)
+      end
+
+      private
+
+      def normalize_options(options)
+        Array(options).flatten.compact.map(&:to_s)
+      end
+    end
+
     # The version of the mkmf-lite library
     MKMF_LITE_VERSION = '0.8.1'
+
+    class << self
+      def configuration
+        @configuration ||= Configuration.new
+      end
+
+      def configure
+        yield configuration
+        reset_memoized_results
+        configuration
+      end
+
+      def extended(object)
+        configured_objects << object
+      end
+
+      private
+
+      def configured_objects
+        @configured_objects ||= []
+      end
+
+      def reset_memoized_results
+        ([self] + configured_objects).each do |object|
+          object.instance_variables.grep(/^@_memoized_/).each do |ivar|
+            object.remove_instance_variable(ivar)
+          end
+        end
+      end
+    end
 
     private
 
@@ -38,7 +104,7 @@ module Mkmf
 
     # rubocop:disable Layout/LineLength
     def cpp_command
-      command = RbConfig::CONFIG['CC'] || RbConfig::CONFIG['CPP'] || File.which('cc') || File.which('gcc') || File.which('cl')
+      command = configuration.compiler || RbConfig::CONFIG['CC'] || RbConfig::CONFIG['CPP'] || File.which('cc') || File.which('gcc') || File.which('cl')
       raise StandardError, 'Compiler not found' unless command
 
       command
@@ -68,6 +134,8 @@ module Mkmf
     def cpp_library_paths
       paths = []
 
+      paths.concat(build_library_directory_options(configuration.lib_dirs))
+
       # Add Homebrew library paths on macOS
       if RbConfig::CONFIG['host_os'].match?(/darwin/)
         # Apple Silicon Macs
@@ -82,6 +150,14 @@ module Mkmf
     memoize :cpp_library_paths
 
     public
+
+    def configure(&block)
+      Mkmf::Lite.configure(&block)
+    end
+
+    def configuration
+      Mkmf::Lite.configuration
+    end
 
     # Check for the presence of the given +header+ file. You may optionally
     # provide a list of directories to search.
@@ -236,18 +312,34 @@ module Mkmf
       directories.flatten.map { |dir| "-I#{dir}" }
     end
 
+    def build_configured_compile_options(command_options)
+      [
+        build_directory_options(configuration.include_dirs),
+        configuration.cflags,
+        command_options
+      ].flatten.compact
+    end
+
+    def build_configured_link_options(library_options)
+      [library_options, configuration.ldflags].flatten.compact
+    end
+
+    def build_library_directory_options(directories)
+      directories.flatten.map { |dir| "-L#{dir}" }
+    end
+
     def build_compile_command(command_options = nil, library_options = nil, paths = {})
       source_file = paths.fetch(:source_file, cpp_source_file)
       output_file = paths.fetch(:output_file, 'conftest.exe')
 
       command_parts = shellwords(cpp_command)
-      command_parts.concat(shellwords(command_options))
+      command_parts.concat(shellwords(build_configured_compile_options(command_options)))
       command_parts.concat(shellwords(cpp_library_paths))
       command_parts.concat(shellwords(cpp_libraries))
       command_parts.concat(shellwords(cpp_defs))
       command_parts.concat(shellwords(cpp_out_file(output_file)))
       command_parts << source_file
-      command_parts.concat(shellwords(library_options))
+      command_parts.concat(shellwords(build_configured_link_options(library_options)))
 
       command_parts
     end

--- a/spec/mkmf_lite_spec.rb
+++ b/spec/mkmf_lite_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Mkmf::Lite do
 
   describe 'constants' do
     example 'version information' do
-      expect(described_class::MKMF_LITE_VERSION).to eq('0.8.1')
+      expect(described_class::MKMF_LITE_VERSION).to eq('0.9.0')
       expect(described_class::MKMF_LITE_VERSION).to be_frozen
     end
   end

--- a/spec/mkmf_lite_spec.rb
+++ b/spec/mkmf_lite_spec.rb
@@ -14,6 +14,16 @@ require 'tmpdir'
 RSpec.describe Mkmf::Lite do
   subject { Class.new{ |obj| obj.extend Mkmf::Lite } }
 
+  after do
+    described_class.configure do |config|
+      config.compiler = nil
+      config.include_dirs = []
+      config.lib_dirs = []
+      config.cflags = []
+      config.ldflags = []
+    end
+  end
+
   def new_probe
     Class.new{ |obj| obj.extend Mkmf::Lite }
   end
@@ -30,6 +40,57 @@ RSpec.describe Mkmf::Lite do
 
   def compile_command_with_linker_arguments(probe)
     probe.send(:build_compile_command, nil, ['-L/tmp/lib dir', '-lfoo'])
+  end
+
+  def configured_compile_command(probe)
+    probe.send(
+      :build_compile_command,
+      nil,
+      ['-lfoo'],
+      :source_file => 'source.c',
+      :output_file => 'output file'
+    )
+  end
+
+  def configure_compiler_defaults
+    described_class.configure do |config|
+      config.compiler = 'custom-cc'
+      config.include_dirs = ['/tmp/include dir']
+      config.lib_dirs = ['/tmp/lib dir']
+      config.cflags = ['-DLOCAL_BUILD=1']
+      config.ldflags = ['-Wl,-rpath,/tmp/lib dir']
+    end
+  end
+
+  def write_configured_header(dir, header)
+    File.write(File.join(dir, header), "#define MKMF_LITE_CONFIGURED_HEADER 1\n")
+  end
+
+  def expect_configured_command_defaults(command)
+    expect(command).to include(
+      'custom-cc',
+      '-I/tmp/include dir',
+      '-L/tmp/lib dir',
+      '-DLOCAL_BUILD=1',
+      '-lfoo',
+      '-Wl,-rpath,/tmp/lib dir'
+    )
+  end
+
+  def expect_configured_command_order(command)
+    expect(command.index('-DLOCAL_BUILD=1')).to be < command.index('source.c')
+    expect(command.index('-Wl,-rpath,/tmp/lib dir')).to be > command.index('source.c')
+  end
+
+  def expect_probe_to_refresh_with_configured_header(probe)
+    header = 'mkmf_lite_configured_header.h'
+
+    Dir.mktmpdir('mkmf lite configured') do |dir|
+      write_configured_header(dir, header)
+      expect(probe.have_header(header)).to be(false)
+      described_class.configure { |config| config.include_dirs = [dir] }
+      expect(probe.have_header(header)).to be(true)
+    end
   end
 
   let(:st_type)   { 'struct stat' }
@@ -299,6 +360,27 @@ RSpec.describe Mkmf::Lite do
 
       expect(command_with_linker_arguments).to include('-L/tmp/lib dir', '-lfoo')
       expect(command_with_linker_arguments.index('-lfoo')).to be > command_with_linker_arguments.index('conftest.c')
+    end
+  end
+
+  describe 'configuration' do
+    example 'exposes global compiler and flag defaults' do
+      configure_compiler_defaults
+
+      command = configured_compile_command(subject)
+
+      expect_configured_command_defaults(command)
+      expect_configured_command_order(command)
+    end
+
+    example 'configuration can be set from an object that extends Mkmf::Lite' do
+      subject.configure { |config| config.cflags = '-DMKMF_LITE_CONFIGURED=1' }
+
+      expect(subject.configuration.cflags).to eq(['-DMKMF_LITE_CONFIGURED=1'])
+    end
+
+    example 'configuration changes clear memoized probe results' do
+      expect_probe_to_refresh_with_configured_header(new_probe)
     end
   end
 


### PR DESCRIPTION
Adds a configure method that takes a block, allowing for very fine control.